### PR TITLE
add gaussian blur effect

### DIFF
--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -99,6 +99,25 @@ def pixellate(value):
     print("Pixellating image with pixel width:", value)
     run_pipeline(operations=lambda input: ops.pixellate(input, value))
 
+@showcase.command(name="gaussian_blur")
+@click.option(
+    "--kernel_size",
+    type=int,
+    default=16,
+    show_default=True,
+    help="the size of the convolution kernel"
+)
+@click.option(
+    "--sigma",
+    type=float,
+    default=4.0,
+    show_default=True,
+    help="gaussian filter stddev"
+)
+def guassian(kernel_size, sigma):
+    print("Running gaussian blur with size and sigma:", kernel_size, sigma)
+    run_pipeline(operations=lambda input: ops.gaussian_blur(input, kernel_size, sigma))
+
 # Blends.
 
 @showcase.command(name="add_blend")

--- a/magic.lock
+++ b/magic.lock
@@ -51,11 +51,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
@@ -131,11 +131,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
@@ -202,11 +202,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.6-hdb05f8b_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
@@ -384,12 +384,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.0-py312hd3ec401_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_4.conda
@@ -641,12 +641,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.10.0-py312h8025657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.0-py312h965bf68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_4.conda
@@ -856,12 +856,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.10.0-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.0-py312hdbc7e53_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
@@ -1042,11 +1042,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.0-py312hd3ec401_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_4.conda
@@ -1199,11 +1199,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.10.0-py312h8025657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.0-py312h965bf68_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_4.conda
@@ -1313,11 +1313,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.6-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.10.0-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.0-py312hdbc7e53_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
@@ -1405,11 +1405,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
@@ -1490,11 +1490,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
@@ -1566,11 +1566,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.6-hdb05f8b_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
@@ -4759,48 +4759,48 @@ packages:
   license_family: BSD
   size: 14467
   timestamp: 1733417051523
-- conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025030505-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/max-25.2.0.dev2025031105-release.conda
   noarch: python
-  sha256: 64d7c1da26831ff9ce866afc7196d11cf9f73a733ee578d9f08c19f372fd7896
-  md5: 666f7089cf6ed0782ff6afd95b72553e
+  sha256: ac499d5355e77d0cae109f5d4e8025e1df030ac80d13c79d3bcd371bea8392e2
+  md5: c0eb2cc18392e7891651ac7b472331c5
   depends:
-  - max-core ==25.2.0.dev2025030505 release
-  - max-python ==25.2.0.dev2025030505 release
-  - mojo-jupyter ==25.2.0.dev2025030505 release
-  - mblack ==25.2.0.dev2025030505 release
+  - max-core ==25.2.0.dev2025031105 release
+  - max-python ==25.2.0.dev2025031105 release
+  - mojo-jupyter ==25.2.0.dev2025031105 release
+  - mblack ==25.2.0.dev2025031105 release
   license: LicenseRef-Modular-Proprietary
-  size: 9901
-  timestamp: 1741151875422
-- conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025030505-release.conda
-  sha256: 53b66bbe15aa5b491a135c5919b912b7db90c5c60787f8d22ed51094a2ae0c4b
-  md5: 4f77f1f9aa01ca72e7b009a63e2915f1
+  size: 9908
+  timestamp: 1741670266302
+- conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.2.0.dev2025031105-release.conda
+  sha256: e8c1723a17290253859d2f7942c1e7a5e0ab2e1d579e6d8048a527c47aac5300
+  md5: 393e04281c091e92c16f150d616bad43
   depends:
-  - mblack ==25.2.0.dev2025030505 release
+  - mblack ==25.2.0.dev2025031105 release
   license: LicenseRef-Modular-Proprietary
-  size: 256137804
-  timestamp: 1741151890120
-- conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025030505-release.conda
-  sha256: 5ea4083a6177f72100140fd0fc96036440dd0336c8a355bf46372bff17ad6160
-  md5: 72ec5c5c82fec7ab6ec946e9bd3a496f
+  size: 253989374
+  timestamp: 1741670273521
+- conda: https://conda.modular.com/max-nightly/linux-aarch64/max-core-25.2.0.dev2025031105-release.conda
+  sha256: 75cd0d0bdeca5018ab205c93ce1c406842ca87e2c0c487677555d3fdd58573d0
+  md5: 48c4d4d428f981bb08102d0c597bd3ee
   depends:
-  - mblack ==25.2.0.dev2025030505 release
+  - mblack ==25.2.0.dev2025031105 release
   license: LicenseRef-Modular-Proprietary
-  size: 258691629
-  timestamp: 1741151875422
-- conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025030505-release.conda
-  sha256: 392f4a5fb004185a081943245b548b480dd8ea3b436b00dea7fd94a2fd95e432
-  md5: 2f5c5a1cee338f62af14e4ce383b94ac
+  size: 256463355
+  timestamp: 1741670266302
+- conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-25.2.0.dev2025031105-release.conda
+  sha256: 5cd126adf97ac4776d6ee9d80a04868f927b93fa4e1b0a323805f31f0e78c29d
+  md5: a054af7139a4bcede966d4c67f5f07ee
   depends:
-  - mblack ==25.2.0.dev2025030505 release
+  - mblack ==25.2.0.dev2025031105 release
   license: LicenseRef-Modular-Proprietary
-  size: 222699755
-  timestamp: 1741152892732
-- conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025030505-release.conda
+  size: 221219866
+  timestamp: 1741671502509
+- conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.2.0.dev2025031105-release.conda
   noarch: python
-  sha256: 4fa75b150f1942f831b9708a59863f3726f0a7ddecd945a63cfc2916d97a7be4
-  md5: 270fa40608eaf61755471e9d91fb270b
+  sha256: 3955f4ced7c670b440c4ac28cc96e00dd892a5c8b4605c0a29c20ebdb8d09813
+  md5: bad4a69cc94d09eb3895b2b3df8e264e
   depends:
-  - max-core ==25.2.0.dev2025030505 release
+  - max-core ==25.2.0.dev2025031105 release
   - click >=8.0.0
   - numpy >=1.18,<2.0
   - sentencepiece >=0.2.0
@@ -4837,14 +4837,14 @@ packages:
   - uvloop >=0.21.0
   - xgrammar ==0.1.11
   license: LicenseRef-Modular-Proprietary
-  size: 127164907
-  timestamp: 1741151890120
-- conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025030505-release.conda
+  size: 125986161
+  timestamp: 1741670273521
+- conda: https://conda.modular.com/max-nightly/linux-aarch64/max-python-25.2.0.dev2025031105-release.conda
   noarch: python
-  sha256: 1f97edadac9f1a973b8e5dccde7237a23daa56e7b6e2d412e53634176cad5de0
-  md5: 2868c23426405131b201b699621c7ed7
+  sha256: c4b1ead704c0a7496710e8c8ea60abe9169d09ec34d38e851e0cd3ba29f94475
+  md5: eb66bc06145762df1afda7769aabed2e
   depends:
-  - max-core ==25.2.0.dev2025030505 release
+  - max-core ==25.2.0.dev2025031105 release
   - click >=8.0.0
   - numpy >=1.18,<2.0
   - sentencepiece >=0.2.0
@@ -4881,14 +4881,14 @@ packages:
   - uvloop >=0.21.0
   - xgrammar ==0.1.11
   license: LicenseRef-Modular-Proprietary
-  size: 129464456
-  timestamp: 1741151875422
-- conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025030505-release.conda
+  size: 128353141
+  timestamp: 1741670266302
+- conda: https://conda.modular.com/max-nightly/osx-arm64/max-python-25.2.0.dev2025031105-release.conda
   noarch: python
-  sha256: b1eb9d6c62aae02b1d9c762cf3e58931ae82b4eba26a6db4881462d3664076e4
-  md5: 31dbde14f2e8c2549ef36e6106222baa
+  sha256: 63e590b27935e91673efa155f5f7c02ce607d21d7e95c59f4c06f23df56c627f
+  md5: 5d3a0782b92c482e1e78c7a4712d8302
   depends:
-  - max-core ==25.2.0.dev2025030505 release
+  - max-core ==25.2.0.dev2025031105 release
   - click >=8.0.0
   - numpy >=1.18,<2.0
   - sentencepiece >=0.2.0
@@ -4925,12 +4925,12 @@ packages:
   - uvloop >=0.21.0
   - xgrammar ==0.1.11
   license: LicenseRef-Modular-Proprietary
-  size: 115816225
-  timestamp: 1741152892732
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025030505-release.conda
+  size: 115194805
+  timestamp: 1741671502509
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-25.2.0.dev2025031105-release.conda
   noarch: python
-  sha256: 0b240303caf92a40e9c1f478a307adcd0b1835a008e99761d85e30bec95f0b68
-  md5: 289079fbe687f566788f12e0af751f9d
+  sha256: dafb87820ce9618da0736f74b6c232d60a15d060b4541de7ac07a3efa8f2ae3e
+  md5: a0e0eb7a78eda1e12555fd2576dcfb6c
   depends:
   - python >=3.9,<3.13
   - click >=8.0.0
@@ -4941,8 +4941,8 @@ packages:
   - typing_extensions >=v4.12.2
   - python
   license: MIT
-  size: 130853
-  timestamp: 1741151875422
+  size: 130657
+  timestamp: 1741670266302
 - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.0-pyhd8ed1ab_0.conda
   sha256: d932404dc610464130db5f36f59cd29947a687d9708daaad369d0020707de41a
   md5: d10024c163a52eeecbb166fdeaef8b12
@@ -4953,18 +4953,18 @@ packages:
   license_family: BSD
   size: 68803
   timestamp: 1735686983426
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025030505-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.2.0.dev2025031105-release.conda
   noarch: python
-  sha256: 6356a278d1ec2663a954558f3445c8053a1c7877e12c933ca760f6b7949ef14b
-  md5: 043fc35a70653e5c18bee8959de9087c
+  sha256: daefda63579f59ad6e9605f47603f4b9db4e06f5266f12d2118ca254fb907dcf
+  md5: 6811564be69a4ab0212a0963dac8ed78
   depends:
-  - max-core ==25.2.0.dev2025030505 release
+  - max-core ==25.2.0.dev2025031105 release
   - python >=3.9,<3.13
   - jupyter_client >=8.6.2,<8.7
   - python
   license: LicenseRef-Modular-Proprietary
-  size: 22986
-  timestamp: 1741151875422
+  size: 22987
+  timestamp: 1741670266302
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
   sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   md5: 2ba8498c1018c1e9c61eb99b973dfe19

--- a/max_cv/operations/effects.py
+++ b/max_cv/operations/effects.py
@@ -1,6 +1,7 @@
 from max.dtype import DType
 from max.graph import ops, TensorType, TensorValue
 from .common import assert_rgb
+import numpy as np
 """Stylized image effects."""
 
 
@@ -22,4 +23,40 @@ def pixellate(image: TensorValue, pixel_width: int) -> TensorValue:
             image
         ],
         out_types=[TensorType(dtype=image.dtype, shape=image.shape)],
+    )[0].tensor
+
+def gaussian_blur(image: TensorValue, kernel_size: int=3, sigma: float=1., padding: bool=False) -> TensorValue:
+    """Apply a gaussian blur affect to the image.
+
+    Args:
+        image: A value representing an incoming image in a graph.
+        kernel_size: The size of the blur kernel to be applied.
+        sigma: Standard deviation used for computing the kernel.
+        padding: Whether to pad the input image to avoid losing pixels at the edge if the image.
+    
+    Returns:
+        A value representing the blurred image.
+    """
+    assert_rgb(image)
+    N = kernel_size
+
+    # generate the kernel
+    ax = np.linspace(-(N - 1) / 2., (N - 1) / 2., N)
+    gauss = np.exp(-0.5 * np.square(ax) / np.square(sigma))
+    kernel = np.outer(gauss, gauss)
+    arr =  (kernel / np.sum(kernel))
+
+    # reshape the expected RSCF layout
+    kernel = ops.constant(arr, dtype=image.dtype)
+    kernel = kernel.reshape((N, N, 1, 1))
+    kernel = kernel.broadcast_to((N, N, 1, 3))
+    
+    pad_value = (N // 2) if padding else 0
+
+    return ops.conv2d(
+        # expects NHWC layout but we only ever have 1 input image
+        image.reshape([1] + image.shape.static_dims),
+        kernel,
+        groups=3,
+        padding=[pad_value] * 4
     )[0].tensor

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -30,7 +30,7 @@ click = ">=8.1.7"
 matplotlib = ">=3.9.0,<4"
 
 [dependencies]
-max = ">=25.2.0.dev2025030505,<26"
+max = ">=25.2.0.dev2025031105,<26"
 pillow = ">=11.0.0,<12"
 
 [environments]

--- a/operations/blend.mojo
+++ b/operations/blend.mojo
@@ -34,7 +34,7 @@ fn _multiply[
     return foreground_pixel * background_pixel
 
 
-@compiler.register("blend", num_dps_outputs=1)
+@compiler.register("blend")
 struct Blend:
     """Performs a two-image blend, using a specified blend function."""
 

--- a/operations/color_correction.mojo
+++ b/operations/color_correction.mojo
@@ -5,7 +5,7 @@ from max.tensor import OutputTensor, InputTensor, foreach
 from runtime.asyncrt import DeviceContextPtr
 
 
-@compiler.register("brightness", num_dps_outputs=1)
+@compiler.register("brightness")
 struct Brightness:
     """Adjusts the brightness of an image."""
 
@@ -28,7 +28,7 @@ struct Brightness:
         foreach[add, target=target](out, ctx)
 
 
-@compiler.register("gamma", num_dps_outputs=1)
+@compiler.register("gamma")
 struct Gamma:
     """Adjusts the gamma of an image."""
 
@@ -51,7 +51,7 @@ struct Gamma:
         foreach[pow, target=target](out, ctx)
 
 
-@compiler.register("luminance", num_dps_outputs=1)
+@compiler.register("luminance")
 struct Luminance:
     """Reduce an RGB image to its luminance channel."""
 

--- a/operations/edge_detection.mojo
+++ b/operations/edge_detection.mojo
@@ -20,7 +20,7 @@ fn edge_clamped_offset_load[
     return tensor.load[width](clamped_index)
 
 
-@compiler.register("sobel", num_dps_outputs=1)
+@compiler.register("sobel")
 struct SobelEdgeDetection:
     """Performs Sobel edge detection."""
 

--- a/operations/effects.mojo
+++ b/operations/effects.mojo
@@ -3,8 +3,7 @@ from utils.index import Index, IndexList
 from max.tensor import foreach, OutputTensor, InputTensor
 from runtime.asyncrt import DeviceContextPtr
 
-
-@compiler.register("pixellate", num_dps_outputs=1)
+@compiler.register("pixellate")
 struct Pixellate:
     """Pixellates an image into small squares."""
 

--- a/operations/passthrough.mojo
+++ b/operations/passthrough.mojo
@@ -4,7 +4,7 @@ from max.tensor import ManagedTensorSlice, foreach, OutputTensor, InputTensor
 from runtime.asyncrt import DeviceContextPtr
 
 
-@compiler.register("passthrough", num_dps_outputs=1)
+@compiler.register("passthrough")
 struct Passthrough:
     @staticmethod
     fn execute[
@@ -31,6 +31,6 @@ struct Passthrough:
     # output shapes in the graph.
     @staticmethod
     fn shape(
-        x: ManagedTensorSlice,
+        x: InputTensor,
     ) raises -> IndexList[x.rank]:
         raise "NotImplemented"

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -19,3 +19,22 @@ def test_pixellate(session: InferenceSession) -> None:
 
     assert result.dtype == DType.float32
     assert result.shape == (4, 6, 3)
+
+def test_gaussian_blur(session: InferenceSession) -> None:
+    device = CPU()
+    image_tensor = generate_test_tensor(device, dtype=DType.float32)
+
+    graph = Graph(
+        "gaussian blur",
+        forward=lambda x: ops.gaussian_blur(x, 3, 3.0, True),
+        input_types=[
+            TensorType(image_tensor.dtype, shape=image_tensor.shape),
+        ],
+    )
+    result = run_graph(graph, image_tensor, session)
+
+    assert result.dtype == DType.float32
+    # This check is a bit iffy depending on the input shape, could be off by 1
+    # in some cases
+    assert result.shape == (4, 6, 3)
+    assert image_tensor != result


### PR DESCRIPTION
- Add gaussian blur to the effect module
- Remove usage of `num_dps_outputs` due to recent breaking changes


Running `magic run showcase gaussian_blur` currently produces this picture of good boy bucky:

![blurred_bucky](https://github.com/user-attachments/assets/a2813213-996c-4b13-8168-d72254d48ffb)


